### PR TITLE
build_automation: version for referenced parent pom must stick to 1.0.0.qualifier

### DIFF
--- a/features/org.polymap.core.platform.feature/pom.xml
+++ b/features/org.polymap.core.platform.feature/pom.xml
@@ -6,9 +6,10 @@
 	<parent>
 		<groupId>org.polymap</groupId>
 		<artifactId>org.polymap.parent</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.polymap.core.platform.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
+	<version>4.0.0-SNAPSHOT</version>
 </project>


### PR DESCRIPTION
version for referenced parent pom must stick to 1.0.0.qualifier
