### PR TITLE
38: [Import] KML

### DIFF
--- a/plugins/org.polymap.core.data.rs/src-test/org/polymap/core/data/rs/RFeatureStoreTests.java
+++ b/plugins/org.polymap.core.data.rs/src-test/org/polymap/core/data/rs/RFeatureStoreTests.java
@@ -16,13 +16,15 @@ package org.polymap.core.data.rs;
 
 import static org.polymap.core.data.Features.iterable;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 import java.io.File;
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.geotools.data.FeatureSource;
 import org.geotools.data.shapefile.ShapefileDataStore;
 import org.geotools.data.shapefile.ShapefileDataStoreFactory;
@@ -30,6 +32,7 @@ import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.DefaultFeatureCollection;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.feature.simple.SimpleFeatureImpl;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.referencing.CRS;
 import org.geotools.util.Utilities;
@@ -40,17 +43,13 @@ import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.filter.FilterFactory;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.polymap.core.data.rs.lucene.LuceneQueryDialect;
+import org.polymap.recordstore.lucene.LuceneRecordStore;
 
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.MultiLineString;
-
-import org.polymap.core.data.rs.lucene.LuceneQueryDialect;
-
-import org.polymap.recordstore.lucene.LuceneRecordStore;
 
 import junit.framework.TestCase;
 
@@ -90,6 +89,23 @@ public class RFeatureStoreTests
         return builder.buildFeatureType();        
     }
     
+    public void testCreateSimpleSchemaAndFeatureWithoutId() throws Exception {
+        log.debug( "creating schema..." );
+        SimpleFeatureType schema = createSimpleSchema();
+        ds.createSchema( schema );
+        RFeatureStore fs = (RFeatureStore)ds.getFeatureSource( schema.getName() );        
+
+        assertEquals( 0, Iterables.size( iterable( fs.getFeatures() ) ) );
+
+        // add feature
+        // SimpleFeatureBuilder always creates a default id
+        DefaultFeatureCollection features = new DefaultFeatureCollection();
+        features.add( new SimpleFeatureImpl( Lists.newArrayList( "value", null ), schema, null ));
+        fs.addFeatures( features );
+        
+         // check size
+        assertEquals( 1, Iterables.size( iterable( fs.getFeatures() ) ) );
+    }
     
     public void testCreateSimpleSchemaAndFeature() throws Exception {
         log.debug( "creating schema..." );

--- a/plugins/org.polymap.core.data.rs/src/org/polymap/core/data/rs/RFeatureStore.java
+++ b/plugins/org.polymap.core.data.rs/src/org/polymap/core/data/rs/RFeatureStore.java
@@ -255,7 +255,7 @@ public class RFeatureStore
                         }
                         // SimpleFeature -> convert
                         else if (feature instanceof SimpleFeature) {
-                            RFeature newFeature = newFeature( feature.getIdentifier().getID() );
+                            RFeature newFeature = newFeature( feature.getIdentifier() != null ? feature.getIdentifier().getID() : null );
                             for (Property prop : feature.getProperties()) {
                                 newFeature.getProperty( prop.getName() ).setValue( prop.getValue() );
                             }


### PR DESCRIPTION
Task-Url: https://github.com/Polymap4/polymap4-p4/issues/issue/38
- add support for null IDs

Der Test org.polymap.core.data.rs.RFeatureStoreTests.testCreateSimpleSchemaAndFeatureWithoutId() zeigt den Fehler. Wenn ein Feature mit ID = null versucht wird zu speichern, gibts es im RFeatureStore eine NPE. Das ist bisher nicht aufgefallen, da wir wahrscheinlich immer die SimpleFeatures mit dem SimpleFeatureBuilder bauen und der eine  DefaultID _fid_12344.._ reinschreibt. Wenn ich aber die Features aus einer anderen Lib bekomme, bspw. geojson wrappe ich die Features jeweils mit _SimpleFeatureImpl(values, schema, ID)_ und hab dann wirklich _null_ als ID da drin.

Wir sollten überlegen, ob wir generell auch in den anderen Importern wie CSV usw. den SimpleFeatureBuilder nicht nutzen oder zumindest die ID explizit auf null setzen, damit der RDataStore entscheiden kann, wie die ID zu bauen ist.
